### PR TITLE
Compilation Fixes

### DIFF
--- a/lectures/2--Paths-and-Identifications/2-1--Paths.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-1--Paths.lagda.md
@@ -361,8 +361,7 @@ module _ {A : Type ℓ} {B : A → Type ℓ₂}
   ΣPathP→PathPΣ' : Σ[ p ∈ (fst x ≡ fst y) ] PathP (λ i → B (p i)) (snd x) (snd y)
          → x ≡ y
   -- Exercise:
-  ΣPathP→PathPΣ' : Σ[ p ∈ (fst x ≡ fst y) ] PathP ? ? ?
-         → x ≡ y
+  ΣPathP→PathPΣ' eq i = {!!}
 
   PathPΣ→ΣPathP' : x ≡ y
          → Σ[ p ∈ (fst x ≡ fst y) ] PathP (λ i → B (p i)) (snd x) (snd y)

--- a/lectures/2--Paths-and-Identifications/2-1--Paths.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-1--Paths.lagda.md
@@ -382,9 +382,8 @@ module _ {A : I → Type ℓ} {B : (i : I) → A i → Type ℓ₂}
   ΣPathP→PathPΣ : Σ[ p ∈ PathP A (fst x) (fst y) ] PathP (λ i → B i (p i)) (snd x) (snd y)
          → PathP (λ i → Σ[ a ∈ A i ] B i a) x y
   -- Exercise:
-  ΣPathP→PathPΣ : Σ[ p ∈ PathP ? ? ? ] PathP ? ? ?
-         → PathP (λ i → Σ[ a ∈ A i ] B i a) x y
-
+  ΣPathP→PathPΣ eq i = {!!}
+  
   PathPΣ→ΣPathP : PathP (λ i → Σ[ a ∈ A i ] B i a) x y
          → Σ[ p ∈ PathP A (fst x) (fst y) ] PathP (λ i → B i (p i)) (snd x) (snd y)
   -- Exercise:

--- a/lectures/2--Paths-and-Identifications/2-1--Paths.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-1--Paths.lagda.md
@@ -334,10 +334,7 @@ depFunExt : {B : A → I → Type ℓ₂}
   → ((x : A) → PathP (B x) (f x) (g x))
   → PathP (λ i → (x : A) → B x i) f g
 -- Exercise:
-depFunExt : {B : A → I → Type}
-  {f : (x : A) → B x i0} {g : (x : A) → B x i1}
-  → ((x : A) → PathP ? ? ?)
-  → PathP ? f g
+depFunExt p i x = {!!}
 ```
 
 Similarly, we can upgrade `congNonDep`{.Agda} to work with dependent

--- a/lectures/2--Paths-and-Identifications/2-1--Paths.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-1--Paths.lagda.md
@@ -151,15 +151,15 @@ proving some useful equalities.
           (f : A → B)
         → (h ∘ g) ∘ f ≡ h ∘ (g ∘ f)
 -- Exercise:
-∘-assoc h g f i x = ?
+∘-assoc h g f i x = {!   !}
 
 ∘-idˡ : (f : A → B) → f ∘ (λ a → a) ≡ f
 -- Exercise:
-∘-idˡ f i x = ?
+∘-idˡ f i x = {!   !}
 
 ∘-idʳ : (f : A → B) → (λ b → b) ∘ f ≡ f
 -- Exercise:
-∘-idʳ f i x = ?
+∘-idʳ f i x = {!   !}
 ```
 
 We can even show that `Bool` has the structure of a *Boolean algebra*.
@@ -225,13 +225,13 @@ cong-bin : (f : A → B → C) {a a' : A} {b b' : B}
          → (q : b ≡ b')
          → (f a b) ≡ (f a' b')
 -- Exercise:
-cong-bin f p q = ?
+cong-bin f p q = {!   !}
 
 cong-∘ : (f : A → B) (g : B → C)
   → (p : x ≡ y)
   → congNonDep (g ∘ f) p ≡ congNonDep g (congNonDep f p)
 -- Exercise:
-cong-∘ f g p = ?
+cong-∘ f g p = {!   !}
 ```
 
 ## Paths in Pair and Function Types
@@ -250,15 +250,15 @@ correct endpoints.
 ```
 ≡-× : {x y : A × B} → (fst x ≡ fst y) × (snd x ≡ snd y) → x ≡ y
 -- Exercise:
-≡-× (p , q) = ?
+≡-× (p , q) = {!   !}
 
 ≡-fst : {x y : A × B} → x ≡ y → (fst x ≡ fst y)
 -- Exercise:
-≡-fst p = ?
+≡-fst p = {!   !}
 
 ≡-snd : {x y : A × B} → x ≡ y → (snd x ≡ snd y)
 -- Exercise:
-≡-snd p = ?
+≡-snd p = {!   !}
 ```
 
 Similarly, what is a path in a function type? It is a function landing
@@ -269,13 +269,13 @@ funExt : {f g : A → B}
   → ((x : A) → f x ≡ g x)
   → f ≡ g
 -- Exercise:
-funExt f = ?
+funExt f = {!   !}
 
 funExt⁻ : {f g : A → B}
   → f ≡ g
   → ((x : A) → f x ≡ g x)
 -- Exercise:
-funExt⁻ p = ?
+funExt⁻ p = {!   !}
 ```
 This is the principle of "function extensionality": to say that `f`
 is the same as `g` means that, for all `x`, `f x` is the same as `g x`.
@@ -290,7 +290,7 @@ funExt2 : {f g : A → B → C}
        (p : (x : A) (y : B) → f x y ≡ g x y)
        → f ≡ g
 -- Exercise:
-funExt2 p i x y = ?
+funExt2 p i x y = {!   !}
 ```
 
 ## Paths over Paths
@@ -316,7 +316,7 @@ functions `A → B` are exactly dependent functions `(x : A) → B` where
 ```
 myPath : (A : Type) (x : A) (y : A) → Type
 -- Exercise: (easy)
-myPath A x y = ?
+myPath A x y = {!   !}
 ```
 
 We can now clear up a lingering question from the previous section. We
@@ -387,8 +387,7 @@ module _ {A : I → Type ℓ} {B : (i : I) → A i → Type ℓ₂}
   PathPΣ→ΣPathP : PathP (λ i → Σ[ a ∈ A i ] B i a) x y
          → Σ[ p ∈ PathP A (fst x) (fst y) ] PathP (λ i → B i (p i)) (snd x) (snd y)
   -- Exercise:
-  ΣPathP→ΣPathP : PathP (λ i → Σ[ a ∈ A i ] B i a) x y
-         → Σ[ p ∈ PathP ? ? ? ] PathP ? ? ?
+  PathPΣ→ΣPathP eq = {!!}
 ```
 
 ## Squares

--- a/lectures/2--Paths-and-Identifications/2-1--Paths.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-1--Paths.lagda.md
@@ -366,8 +366,7 @@ module _ {A : Type ℓ} {B : A → Type ℓ₂}
   PathPΣ→ΣPathP' : x ≡ y
          → Σ[ p ∈ (fst x ≡ fst y) ] PathP (λ i → B (p i)) (snd x) (snd y)
   -- Exercise:
-  PathPΣ→ΣPathP' : x ≡ y
-         → Σ[ p ∈ (fst x ≡ fst y) ] PathP ? ? ?
+  PathPΣ→ΣPathP' eq = {!!}
 
 ```
 

--- a/lectures/2--Paths-and-Identifications/2-10--Higher-Types.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-10--Higher-Types.lagda.md
@@ -23,7 +23,7 @@ open import 2--Paths-and-Identifications.2-9--Univalence
 ```
 -->
 
-So far, we have seen a heirarchy of types of increasing complexity:
+So far, we have seen a hierarchical of types of increasing complexity:
 contractible types followed by propositions and then sets. But not all
 types are sets. In particular, via univalence, it is easy to check
 that `Type`{.Agda} itself is not a set.

--- a/lectures/2--Paths-and-Identifications/2-10--Higher-Types.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-10--Higher-Types.lagda.md
@@ -23,7 +23,7 @@ open import 2--Paths-and-Identifications.2-9--Univalence
 ```
 -->
 
-So far, we have seen a hierarchical of types of increasing complexity:
+So far, we have seen a hierarchy of types of increasing complexity:
 contractible types followed by propositions and then sets. But not all
 types are sets. In particular, via univalence, it is easy to check
 that `Type`{.Agda} itself is not a set.

--- a/lectures/2--Paths-and-Identifications/2-2--Isomorphisms-and-Path-Algebra.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-2--Isomorphisms-and-Path-Algebra.lagda.md
@@ -86,7 +86,7 @@ always an isomorphism, acting as its own inverse.
 ```
 idIso : (A : Type ℓ) → Iso A A
 -- Exercise:
-idIso A = ?
+idIso A = {!   !}
 ```
 
 And, the data of an isomorphism is completely symmetric between `A`
@@ -95,7 +95,7 @@ and `B`, so given any isomorphism, we can flip it around.
 ```
 invIso : Iso A B → Iso B A
 -- Exercise:
-invIso f = ?
+invIso f = {!   !}
 ```
 
 Isomorphisms compose like functions do, but we will prove this a
@@ -150,16 +150,16 @@ OtherIsoBoolRedOrBlue = iso to fro s r
 {-
   where
     to : Bool → RedOrBlue
-    to x = ?
+    to x = {!   !}
 
     fro : RedOrBlue → Bool
-    fro x = ?
+    fro x = {!   !}
 
     s : section to fro
-    s x = ?
+    s x = {!   !}
 
     r : retract to fro
-    r x = ?
+    r x = {!   !}
 -}
   where
     to : Bool → RedOrBlue
@@ -254,6 +254,8 @@ Bool-⊤⊎⊤-Iso = iso Bool→⊤⊎⊤ ⊤⊎⊤→Bool sec ret
   where
     sec : section Bool→⊤⊎⊤ ⊤⊎⊤→Bool
 --  Exercise:
+--  Hint: Check your definitions for Bool→⊤⊎⊤ and ⊤⊎⊤→Bool
+--  in 1-2 if this throws an error.
 --  sec x = ?
     sec (inl tt) = refl
     sec (inr tt) = refl

--- a/lectures/2--Paths-and-Identifications/2-3--Transport-and-J.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-3--Transport-and-J.lagda.md
@@ -328,8 +328,14 @@ prove this isomorphism!) mvrnote: this might be too silly to include
 ≡Iso≡∅ : (X : Type) (n m : ∅) → Iso (n ≡ m) X
 -- Exercise:
 ≡Iso≡∅ X m n = ?
-≡Iso≡∅ X () lol baited
-≡Iso≡∅' : (X : Type) (n m : ∅) → Iso (n ≡ m) X You can do it the long way of course
+≡Iso≡∅ X () -- lol baited
+
+-- You can do it the long way of course
+≡Iso≡∅' : (X : Type) (n m : ∅) → Iso (n ≡ m) X
+≡Iso≡∅' X n m = iso (encode n m) (decode n m) (sec n m) (ret n m)
+  where
+    code : ∅ → ∅ → Type
+    code x y = X
 
     encodeRefl : (x : ∅) → code x x
     encodeRefl ()

--- a/lectures/2--Paths-and-Identifications/2-3--Transport-and-J.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-3--Transport-and-J.lagda.md
@@ -99,7 +99,7 @@ Give it a try in the reverse:
 ```
 false≢true : ¬ false ≡ true
 -- Exercise:
-false≢true p = ?
+false≢true p = {!   !}
 ```
 
 ## The J Rule
@@ -215,7 +215,7 @@ That this is a section is similar, after splitting into cases:
 ```
     sec : (x y : Bool) → section (encode x y) (decode x y)
     -- Exercise:
-    section p = ?
+    sec p = {!   !}
 ```
 
 For the retract, we have another trick. The proof is easy if we are
@@ -296,26 +296,26 @@ deleted.
   where
     code : ⊤ → ⊤ → Type
     -- Exercise:
-    code x y = ?
+    code x y = {!   !}
 
     encodeRefl : (x : ⊤) → code x x
     -- Exercise:
-    encodeRefl x = ?
+    encodeRefl x = {!   !}
 
     encode : (x y : ⊤) → x ≡ y → code x y
     encode x y p = subst (λ z → code x z) p (encodeRefl x)
 
     decode : (x y : ⊤) → code x y → x ≡ y
     -- Exercise:
-    decode x y c = ?
+    decode x y c = {!   !}
 
     sec : (x y : ⊤) → section (encode x y) (decode x y)
     -- Exercise:
-    sec x y c = ?
+    sec x y c = {!   !}
 
     retRefl : (x : ⊤) → decode x x (encode x x refl) ≡ refl
     -- Exercise:
-    retRefl x = ?
+    retRefl x = {!   !}
 
     ret : (x y : ⊤) → retract (encode x y) (decode x y)
     ret x y = J (λ c p → decode x c (encode x c p) ≡ p) (retRefl x)
@@ -327,7 +327,7 @@ prove this isomorphism!) mvrnote: this might be too silly to include
 ```
 ≡Iso≡∅ : (X : Type) (n m : ∅) → Iso (n ≡ m) X
 -- Exercise:
-≡Iso≡∅ X m n = ?
+≡Iso≡∅ X m n = {!   !}
 ≡Iso≡∅ X () -- lol baited
 
 -- You can do it the long way of course
@@ -368,26 +368,26 @@ For `ℕ`{.Agda}, we also already have a candidate for `code`, that is,
 
     encodeRefl : (n : ℕ) → code n n
     -- Exercise:
-    encodeRefl n = ?
+    encodeRefl n = {!   !}
 
     encode : (n m : ℕ) → n ≡ m → code n m
     encode n m p = subst (λ z → code n z) p (encodeRefl n)
 
     decode : (n m : ℕ) → code n m → n ≡ m
     -- Exercise:
-    decode n m c = ?
+    decode n m c = {!   !}
 
     sec : (x y : ℕ) → section (encode x y) (decode x y)
     -- Exercise:
-    sec x y p = ?
+    sec x y p = {!   !}
 
     retRefl : (x : ℕ) → decode x x (encode x x refl) ≡ refl
     -- Exercise:
-    retRefl x = ?
+    retRefl x = {!   !}
 
     ret : (x y : ℕ) → retract (encode x y) (decode x y)
     -- Exercise:
-    ret x y p = ?
+    ret x y p = {!   !}
 ```
 
 And one final application: disjoint unions. We haven't yet got a

--- a/lectures/2--Paths-and-Identifications/2-4--Composition-and-Filling.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-4--Composition-and-Filling.lagda.md
@@ -143,7 +143,7 @@ suc n ≤ suc m = n ≤ m
 
 take : (n : ℕ) (L : List A) → BooleanPartial (n ≤ length L) (List A)
 -- Exercise:
-take n L = ?
+take n L = {!   !}
 ```
 
 ## Partial Elements
@@ -273,7 +273,7 @@ Try it yourself: describe a formula which gives the two sides of a box
 ```
 sides-of-square : I → I → I
 -- Exercise:
-sides-of-square i j = ?
+sides-of-square i j = {!   !}
 ```
 
 How about a three dimensional example. Come up with a formula to
@@ -298,7 +298,7 @@ of the sides.
 ```
 exercise-shape : I → I → I → I
 -- Exercise:
-exercise-shape i j k = ?
+exercise-shape i j k = {!   !}
 ```
 
 
@@ -632,13 +632,13 @@ Now we have, in fact, seen all of these faces before.
 diamondFaces : {x y z : A} (p : x ≡ y) (q : y ≡ z)
   → (i : I) → (j : I) → I → Partial (∂ i ∨ ∂ j) A
 -- Exercise:
-diamondFaces p q i j k (i = i0) = ?
-diamondFaces p q i j k (i = i1) = ?
-diamondFaces p q i j k (j = i0) = ?
-diamondFaces p q i j k (j = i1) = ?
+diamondFaces p q i j k (i = i0) = {!   !}
+diamondFaces p q i j k (i = i1) = {!   !}
+diamondFaces p q i j k (j = i0) = {!   !}
+diamondFaces p q i j k (j = i1) = {!   !}
 
 -- Exercise:
-diamond p q i j = hcomp (diamondFaces p q i j) ?
+diamond p q i j = hcomp (diamondFaces p q i j) {!   !}
 ```
 
 This is not the only way to do it! The composition problems that
@@ -665,10 +665,10 @@ same `diamond` square, but using the following cube:
 ```
 diamondFacesAlt : {x y z : A} (p : x ≡ y) (q : y ≡ z) → (i : I) → (j : I) → I → Partial (∂ i ∨ ∂ j) A
 -- Exercise:
-diamondFacesAlt p q i j k (i = i0) = ?
-diamondFacesAlt p q i j k (i = i1) = ?
-diamondFacesAlt p q i j k (j = i0) = ?
-diamondFacesAlt p q i j k (j = i1) = ?
+diamondFacesAlt p q i j k (i = i0) = {!   !}
+diamondFacesAlt p q i j k (i = i1) = {!   !}
+diamondFacesAlt p q i j k (j = i0) = {!   !}
+diamondFacesAlt p q i j k (j = i1) = {!   !}
 
 diamondAlt : (p : x ≡ y) (q : y ≡ z) → Square p q p q
 diamondAlt {x = x} p q i j = hcomp (diamondFacesAlt p q i j) x
@@ -698,14 +698,14 @@ top face is the path-between-paths that we want.
 ```
 assoc-faces : {w x y z : A} (r : w ≡ x) (p : x ≡ y) (q : y ≡ z) → (i : I) → (j : I) → (k : I) → Partial (∂ i ∨ ∂ j) A
 -- Exercise:
-assoc-faces         r p q i j k (i = i0) = ?
-assoc-faces         r p q i j k (i = i1) = ?
-assoc-faces {w = w} r p q i j k (j = i0) = ?
-assoc-faces         r p q i j k (j = i1) = ?
+assoc-faces         r p q i j k (i = i0) = {!   !}
+assoc-faces         r p q i j k (i = i1) = {!   !}
+assoc-faces {w = w} r p q i j k (j = i0) = {!   !}
+assoc-faces         r p q i j k (j = i1) = {!   !}
 
 assoc-base : {w x y z : A} (r : w ≡ x) (p : x ≡ y) (q : y ≡ z) → Square (r ∙ p) (r ∙ p) refl refl
 -- Exercise:
-assoc-base r p q i j = ?
+assoc-base r p q i j = {!   !}
 
 assoc : (r : w ≡ x) (p : x ≡ y) (q : y ≡ z)
   → r ∙ (p ∙ q) ≡ (r ∙ p) ∙ q
@@ -750,14 +750,14 @@ The faces are straightforward to construct if you stare at the diagram.
 ```
 lUnit-faces : {x y : A} (p : x ≡ y) → (i : I) → (j : I) → (k : I) → Partial (~ i ∨ ∂ j) A
 -- Exercise:
-lUnit-faces         p i j k (i = i0) = ? Constant in the `j` direction
-lUnit-faces {x = x} p i j k (j = i0) = ? Completely constant
-lUnit-faces         p i j k (j = i1) = ? Constructed from `p` using connections
+lUnit-faces         p i j k (i = i0) = {!   !} -- Constant in the `j` direction
+lUnit-faces {x = x} p i j k (j = i0) = {!   !} -- Completely constant
+lUnit-faces         p i j k (j = i1) = {!   !} -- Constructed from `p` using connections
 
 lUnit-base : {x y : A} (p : x ≡ y) → Square p refl refl (sym p)
 -- Exercise:
-lUnit-base p i j = ?
-Hint: Constructed from `p` using connections in a different way
+lUnit-base p i j = {!   !}
+-- Hint: Constructed from `p` using connections in a different way
 
 lUnit : (p : x ≡ y) → p ≡ refl ∙ p
 lUnit {x = x} p i j = hcomp (lUnit-faces p i j) (lUnit-base p i j)

--- a/lectures/2--Paths-and-Identifications/2-6--Propositions.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-6--Propositions.lagda.md
@@ -514,7 +514,7 @@ isPropRetract :
   → (h : retract f g)
   → isProp B → isProp A
 -- Exercise:
-isPropRetract f g h isPropB x y i =
+isPropRetract f g h isPropB x y i = {!!}
 ```
 
 In particular, any type equivalent to a proposition is also a

--- a/lectures/2--Paths-and-Identifications/2-6--Propositions.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-6--Propositions.lagda.md
@@ -107,7 +107,7 @@ Super Hint: It's exactly the connection square
 ```
 isContrSingl : (a : A) → isContr (singl a)
 -- Exercise:
-isContrSingl a = ?
+isContrSingl a = {!   !}
 ```
 
 We show that our type `⊤`{.Agda}, which was defined to have only a
@@ -116,7 +116,7 @@ single element `tt`{.Agda}, is contractible.
 ```
 isContr⊤ : isContr ⊤
 -- Exercise:
-isContr⊤ = ?
+isContr⊤ = {!   !}
 ```
 
 On the other hand, `∅`{.Agda} is not contractible: it doesn't have any
@@ -125,7 +125,7 @@ elements at all.
 ```
 ¬isContr∅ : ¬ isContr ∅
 -- Exercise:
-¬isContr∅ = ?
+¬isContr∅ = {!   !}
 ```
 
 Any two contractible types are isomorphic.
@@ -133,7 +133,7 @@ Any two contractible types are isomorphic.
 ```
 isContr→Iso : {A : Type ℓ} {B : Type ℓ'} → isContr A → isContr B → Iso A B
 -- Exercise:
-isContr→Iso c c' = ?
+isContr→Iso c c' = {!   !}
 
 isContrIso⊤ : {A : Type}  → isContr A → Iso A ⊤
 isContrIso⊤ c = isContr→Iso c isContr⊤
@@ -154,7 +154,7 @@ mvrnote: Move to extras? There is a unique map from `∅`{.Agda} to any type.
 ```
 ∅-rec-unique : {A : Type ℓ} → isContr (∅ → A)
 -- Exercise:
-∅-rec-unique = ?
+∅-rec-unique = {!   !}
 ```
 
 If `B : A → Type` is a family of contractible types depending on `A`,
@@ -165,8 +165,8 @@ isContrFun : ∀ {A : Type ℓ} {B : A → Type ℓ}
            → ((a : A) → isContr (B a))
            → isContr ((a : A) → B a)
 -- Exercise:
-fst (isContrFun c) = ?
-snd (isContrFun c) f i a = ?
+fst (isContrFun c) = {!   !}
+snd (isContrFun c) f i a = {!   !}
 ```
 
 In particular, the map `(λ _. tt) : A → ⊤` (which always exists for
@@ -179,8 +179,8 @@ involve some `hcomp`{.Agda}s.
 ```
 isContrisContr≡ : {A : Type ℓ} (c : isContr A) (a b : A) → isContr (a ≡ b)
 -- Exercise:
-fst (isContrisContr≡ (c₀ , c) a b) = ?
-snd (isContrisContr≡ (c₀ , c) a b) = ?
+fst (isContrisContr≡ (c₀ , c) a b) = {!   !}
+snd (isContrisContr≡ (c₀ , c) a b) = {!   !}
 ```
 
 ## Aside: Equational Reasoning
@@ -289,6 +289,7 @@ isProp-≡Bool false false = isProp⊤
 
 isProp-≡ℕ : (n m : ℕ) → isProp (n ≡ℕ m)
 -- Exercise:
+isProp-≡ℕ n m = {!!}
 ```
 
 The ordering on the natural numbers is also a proposition.
@@ -307,7 +308,7 @@ that `Bool`{.Agda} is not a proposition.
 ```
 ¬isPropBool : ¬ isProp Bool
 -- Exercise:
-¬isPropBool pBool = ?
+¬isPropBool pBool = {!   !}
 ```
 
 mvrnote: and do similarly for `ℕ`?
@@ -433,7 +434,7 @@ isPropΠ : {A : Type ℓ} {B : A → Type ℓ'}
             (p : ∀ a → isProp (B a))
           → isProp (∀ a → B a)
 -- Exercise:
-isPropFun p f g = ?
+isPropΠ p f g = {!!}
 ```
 
 As a special case of this, we get "implies". If `A` and `B` are
@@ -452,7 +453,7 @@ contractible as soon as `B` is contractible.
 ```
 isContr→ : isContr B → isContr (A → B)
 -- Exercise:
-isContr→ (cB , hB) = ?
+isContr→ (cB , hB) = {!   !}
 ```
 
 As a special case of implication, we find that type negation `¬ A` is
@@ -468,7 +469,7 @@ The "and" of two proposition `A` and `B` is the type of pairs `A × B`.
 ```
 isProp× : isProp A → isProp B → isProp (A × B)
 -- Exercise:
-isProp pA pB = ?
+isProp× pA pB = {!   !}
 ```
 
 Similarly to `→`, if `A` and `B` are true (contracible), then `A × B` should
@@ -477,7 +478,7 @@ also be contractible.
 ```
 isContr× : isContr A → isContr B → isContr (A × B)
 -- Exercise:
-isContr cA cB = ?
+isContr× cA cB = {!   !}
 ```
 
 For contractibility, the converse holds: if the product is
@@ -485,7 +486,7 @@ contractible then the inputs must have been.
 ```
 isContr×-conv : isContr (A × B) → isContr A × isContr B
 -- Exercise:
-isContr×-conv cAB = ?
+isContr×-conv cAB = {!   !}
 ```
 
 By contrast, disjoint unions of contractible types are not
@@ -501,7 +502,7 @@ then their disjoint union is still a proposition.
 ```
 isPropExclusive⊎ : isProp A → isProp B → ¬ (A × B) → isProp (A ⊎ B)
 -- Exercise:
-isPropExclusive⊎ pA pB disjoint x y = ?
+isPropExclusive⊎ pA pB disjoint x y = {!   !}
 ```
 
 If `A` is a retract of `B`, then in some sense `A` is a continuous
@@ -550,14 +551,14 @@ does not imply that the two components are.
 ```
 ¬isProp×-conv : ¬ (∀ (A B : Type) → isProp (A × B) → isProp A × isProp B)
 -- Exercise: (Hint: ∅)
-¬isProp×-conv = ?
+¬isProp×-conv = {!   !}
 ```
 
 mvrnote: prose. the other direction is annoying to state without something like isIso
 ```
 isProp→IsoDiag : isProp A → Iso A (A × A)
 -- Exercise:
-isProp→IsoDiag pA = ?
+isProp→IsoDiag pA = {!   !}
 ```
 
 If a type has at most one element and also has an element, then that
@@ -567,8 +568,9 @@ it is contractible.
 ```
 Prop-with-point-isContr : Iso (isProp A) (A → isContr A)
 -- Exercise: (use propExt)
-Prop-with-point-isContr = ?
+Prop-with-point-isContr = {!   !}
 
+  where
     fro : (A → isContr A) → isProp A
     fro c x y =
           x         ≡⟨ sym (snd (c x) x) ⟩
@@ -611,13 +613,13 @@ It is not difficult to show we can go from one to the other.
 isPred→∀isProp : {A : Type ℓ} {B : A → Type ℓ'}
                → isPred B → ∀ a → isProp (B a)
 -- Exercise:
-isPred→∀isProp p = ?
+isPred→∀isProp p = {!   !}
 
 ∀isProp→isPred : {A : Type ℓ} {B : A → Type ℓ'}
                → (∀ a → isProp (B a)) → isPred B
 -- mvrnote: does this need a hint?
 -- Exercise:
-∀isProp→isPred p = ?
+∀isProp→isPred p = {!   !}
 ```
 
 This lets us easily prove an upgraded, dependent version of
@@ -735,7 +737,7 @@ we can get an implication `∃ A → P` whenever `P` is a proposition.
 ```
 ∃-map : (A → B) → (∃ A → ∃ B)
 -- Exercise:
-∃-map f = ?
+∃-map f = {!   !}
 ```
 
 When `P` is already a proposition, truncating it should do nothing:
@@ -743,8 +745,8 @@ When `P` is already a proposition, truncating it should do nothing:
 ```
 isProp→Iso∃ : isProp P → Iso P (∃ P)
 -- Exercise:
-isProp→Iso∃ isPropP = ?
-Hint: use `propExt`
+isProp→Iso∃ isPropP = {!   !}
+-- Hint: use `propExt`
 ```
 
 If `P : A → Type` is a family of propositions on `A` --- that is, a
@@ -799,8 +801,8 @@ mvrnote: prose
 ```
 ¬¬-∃-Iso : Iso (¬ ¬ ∃ A) (¬ ¬ A)
 -- Exercise: Hint: use `propExt`
-¬¬-∃-Iso = ?
-
+¬¬-∃-Iso = {!   !}
+  where
     fro : ¬ ¬ A → ¬ ¬ ∃ A
     fro ¬¬a ¬∃a = ¬¬a (λ x → ¬∃a ∣ x ∣)
 ```
@@ -878,16 +880,16 @@ Dec-extract d f = {!!}
 
 Dec-Idem : Dec (Dec A) → Dec A
 -- Exercise:
-Dec-Idem d = ?
+Dec-Idem d = {!   !}
 
 isProp-Dec : isProp A → isProp (Dec A)
 -- Exercise:
-isProp-Dec isPropA = ?
+isProp-Dec isPropA = {!   !}
 
 ∃-Dec-Iso : Iso (Dec (∃ A)) (∃ (Dec A))
 -- Exercise: Hint: use `propExt`
-∃-Dec-Iso = ?
-
+∃-Dec-Iso = {!   !}
+  where
     fro-lemma : Dec A → Dec (∃ A)
     fro-lemma (yes p) = yes ∣ p ∣
     fro-lemma (no ¬p) = no (∃-rec isProp∅ ¬p)
@@ -897,7 +899,7 @@ isProp-Dec isPropA = ?
 
 Dec→SplitSupport : Dec A → (∃ A → A)
 -- Exercise:
-Dec→SplitSupport d = ?
+Dec→SplitSupport d = {!   !}
 ```
 
 mvrnote: would be good to extend this to Hedberg's theorem, but that

--- a/lectures/2--Paths-and-Identifications/2-8--Equivalences.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-8--Equivalences.lagda.md
@@ -334,8 +334,8 @@ correspondence.
 -- graphEquivIsOneToOne : {A B : Type} (e : A ≃ B)
 --                      → isOneToOne (graph (fst e))
 -- -- Exercise:
-graphEquivIsOneToOne e = ?
-graphEquivIsOneToOne (e , p) = (isFunctionalGraph e) , p
+-- graphEquivIsOneToOne e = ?
+-- graphEquivIsOneToOne (e , p) = (isFunctionalGraph e) , p
 ```
 
 It is also possible to go the other way, but again we'll come back to

--- a/lectures/2--Paths-and-Identifications/2-8--Equivalences.lagda.md
+++ b/lectures/2--Paths-and-Identifications/2-8--Equivalences.lagda.md
@@ -288,7 +288,7 @@ The graph of a function is a functional relation --- hence the name.
 ```
 isFunctionalGraph : {A B : Type ℓ} (f : A → B) → isFunctional (graph f)
 -- Exercise:
-isFuncationalGraph f a = ?
+isFunctionalGraph f a = ?
 ```
 
 On the other hand, any functional relation gives rise to a function.
@@ -366,3 +366,4 @@ pathToEquivRefl : {A : Type ℓ} → pathToEquiv refl ≡ idEquiv A
 pathToEquivRefl {A = A} = equivEq (λ i x → transp (λ _ → A) i x)
 ```
 
+ 


### PR DESCRIPTION
This pull request contains necessary fixes to compile the Agda files when working through the tutorials. These are mostly minor, including name mismatches, duplicate definitions, missing goals, and parse errors.